### PR TITLE
Allow specifying an endpoint for downloads

### DIFF
--- a/Sources/tinys3/AWSRequest.swift
+++ b/Sources/tinys3/AWSRequest.swift
@@ -79,11 +79,11 @@ struct AWSRequest {
     }
 
     static func downloadRequest(
-        endpoint: S3Endpoint = .default,
         bucket: String,
         key: String,
         range: Range<Int>? = nil,
         credentials: AWSCredentials,
+        endpoint: S3Endpoint = .default,
         date: Date = Date()
     ) -> AWSRequest {
         AWSRequest(

--- a/Sources/tinys3/S3Client.swift
+++ b/Sources/tinys3/S3Client.swift
@@ -71,9 +71,16 @@ public struct S3Client {
     public func download(
         objectWithKey key: String,
         inBucket bucket: String,
-        progressCallback: ProgressCallback? = nil
+        progressCallback: ProgressCallback? = nil,
+        endpoint: S3Endpoint = .default
     ) async throws -> URL {
-        let request = AWSRequest.downloadRequest(bucket: bucket, key: key, credentials: self.credentials).urlRequest
+        let request = AWSRequest.downloadRequest(
+            bucket: bucket,
+            key: key,
+            credentials: self.credentials,
+            endpoint: endpoint
+        ).urlRequest
+
         return try await DownloadOperation(request: request).start(progressCallback: progressCallback)
     }
 


### PR DESCRIPTION
Allows much faster downloads without requiring parallelization (for way more money)